### PR TITLE
Self closing tag

### DIFF
--- a/test/turbo_xml_test.exs
+++ b/test/turbo_xml_test.exs
@@ -34,6 +34,16 @@ defmodule TurboXmlTest do
     assert xml_bin === "<?xml version=\"1.0\"?><nilTest></nilTest>"
   end
 
+  test "self closing tag" do
+    xml_bin = TurboXml.node("self_closing") |> IO.iodata_to_binary()
+    assert xml_bin === "<self_closing/>"
+  end
+
+  test "self closing tag with attributes" do
+    xml_bin = TurboXml.node("self_closing", id: "tag") |> IO.iodata_to_binary()
+    assert xml_bin === "<self_closing id=\"tag\"/>"
+  end
+
   test "bad xml" do
     xml = node "bad" do
       "<iambad&&\"yo'>"
@@ -64,7 +74,6 @@ defmodule TurboXmlTest do
     assert_raise RuntimeError, fn ->
       node "john kennedy" do  end
     end
-
   end
 
   test "xml handle integer" do

--- a/test/turbo_xml_test.exs
+++ b/test/turbo_xml_test.exs
@@ -9,7 +9,7 @@ defmodule TurboXmlTest do
         "text1"
       end
     end
-    assert :erlang.iolist_to_binary(xml) === "<?xml version=\"1.0\"?><n1>text1</n1>"
+    assert IO.iodata_to_binary(xml) === "<?xml version=\"1.0\"?><n1>text1</n1>"
   end
 
   test "dynamic turbo xml" do
@@ -22,7 +22,7 @@ defmodule TurboXmlTest do
         end
       end
     end
-    assert :erlang.iolist_to_binary(xml) ===
+    assert IO.iodata_to_binary(xml) ===
       "<?xml version=\"1.0\"?><root><n1>t1</n1><n2>t2</n2><n3>t3</n3></root>"
   end
 
@@ -30,7 +30,7 @@ defmodule TurboXmlTest do
     xml = doc do
       node "nilTest" do end
     end
-    xml_bin = :erlang.iolist_to_binary(xml)
+    xml_bin = IO.iodata_to_binary(xml)
     assert xml_bin === "<?xml version=\"1.0\"?><nilTest></nilTest>"
   end
 
@@ -48,19 +48,19 @@ defmodule TurboXmlTest do
     xml = node "bad" do
       "<iambad&&\"yo'>"
     end
-    xml_bin = :erlang.iolist_to_binary(xml)
+    xml_bin = IO.iodata_to_binary(xml)
     assert xml_bin === "<bad>&lt;iambad&amp;&amp;&quot;yo&apos;&gt;</bad>"
   end
 
   test "atom node name" do
     xml = node :node do end
-    xml_bin = :erlang.iolist_to_binary(xml)
+    xml_bin = IO.iodata_to_binary(xml)
     assert xml_bin === "<node></node>"
   end
 
   test "xml attributes" do
     xml = node "node", id: "me!", class: "ftou" do  end
-    xml_bin = :erlang.iolist_to_binary(xml)
+    xml_bin = IO.iodata_to_binary(xml)
     assert xml_bin === "<node id=\"me!\" class=\"ftou\"></node>"
   end
 
@@ -78,13 +78,13 @@ defmodule TurboXmlTest do
 
   test "xml handle integer" do
     xml_bin = node "int_number", int: 1 do end
-      |> :erlang.iolist_to_binary()
+      |> IO.iodata_to_binary()
     assert xml_bin === "<int_number int=\"1\"></int_number>"
   end
 
   test "xml handle decimal" do
     xml_bin = node "dec_number", dec: 10.5 do end
-     |> :erlang.iolist_to_binary()
+     |> IO.iodata_to_binary()
     assert xml_bin === "<dec_number dec=\"10.5\"></dec_number>"
   end
 


### PR DESCRIPTION
Two commits here:

1. Implementation of self closing tag but just writing `node` conflicts with the build-in `node/1` function, so a refactoring/prefixing may be called for in our library
2. Substitution of IO.iodata_to_binary for :erlang.iolist_to_binary because they are exactly the same (https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/io.ex#L481)